### PR TITLE
Do no use ImageGrab to write files

### DIFF
--- a/Wrapper.ipynb
+++ b/Wrapper.ipynb
@@ -25,13 +25,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import math\n",
     "import subprocess\n",
     "import tkinter as tk\n",
     "import turtle\n",
     "\n",
     "import numpy as np\n",
     "from scipy.stats import linregress\n",
-    "from PIL import ImageGrab"
+    "from PIL import Image"
    ]
   },
   {
@@ -47,17 +48,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def dump_gui(window, filename = \"gui_image_grabbed.png\"):\n",
+    "def dump_gui(canvas, filename = \"gui_image_grabbed.png\"):\n",
     "    \"\"\"\n",
     "    takes a png screenshot of a tkinter window, and saves it on in cwd\n",
     "    \"\"\"\n",
-    "    print('...dumping gui window to png')\n",
-    "\n",
-    "    x0 = window.winfo_rootx()\n",
-    "    y0 = window.winfo_rooty()\n",
-    "    x1 = x0 + window.winfo_width()\n",
-    "    y1 = y0 + window.winfo_height()\n",
-    "    ImageGrab.grab().crop((x0, y0, x1, y1)).save(filename)"
+    "    print(f'...dumping gui window to png: {filename}')\n",
+    "    import io\n",
+    "    \n",
+    "    ps = canvas.postscript(colormode=\"mono\")\n",
+    "    im = Image.open(io.BytesIO(ps.encode('utf-8')))\n",
+    "    im.save(filename)"
    ]
   },
   {
@@ -114,10 +114,10 @@
     "t.penup()\n",
     "t.goto(-200, -175)\n",
     "t.pendown()\n",
-    "draw_sierpinski(t, 400, 3)\n",
+    "draw_sierpinski(t, 400, 2)\n",
     "t.hideturtle()\n",
     "\n",
-    "dump_gui(root, \"Triangle1.png\")\n",
+    "dump_gui(canvas, \"Triangle1.png\")\n",
     "\n",
     "root.mainloop()"
    ]
@@ -131,7 +131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -175,7 +175,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,7 +186,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -202,7 +202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -230,17 +230,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "...dumping gui window to png\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "root = tk.Tk()\n",
     "canvas = tk.Canvas(root, width=1920, height=1080)\n",
@@ -258,14 +250,14 @@
     "snowflake(t, length, 6) \n",
     "t.hideturtle()\n",
     "\n",
-    "dump_gui(root, \"Koch Curve.png\")\n",
+    "dump_gui(canvas, \"Koch Curve.png\")\n",
     "\n",
     "root.mainloop()  "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -324,29 +316,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "...dumping gui window to png\n"
-     ]
-    },
-    {
-     "ename": "KeyboardInterrupt",
-     "evalue": "",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
-      "Cell \u001b[1;32mIn[49], line 25\u001b[0m\n\u001b[0;32m     21\u001b[0m sierpinski(canvas, i, t, size)\n\u001b[0;32m     23\u001b[0m dump_gui(root, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mPentagon.png\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m---> 25\u001b[0m \u001b[43mroot\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmainloop\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[1;32mc:\\Python312\\Lib\\tkinter\\__init__.py:1505\u001b[0m, in \u001b[0;36mMisc.mainloop\u001b[1;34m(self, n)\u001b[0m\n\u001b[0;32m   1503\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mmainloop\u001b[39m(\u001b[38;5;28mself\u001b[39m, n\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m0\u001b[39m):\n\u001b[0;32m   1504\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"Call the mainloop of Tk.\"\"\"\u001b[39;00m\n\u001b[1;32m-> 1505\u001b[0m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtk\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmainloop\u001b[49m\u001b[43m(\u001b[49m\u001b[43mn\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[1;31mKeyboardInterrupt\u001b[0m: "
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "root = tk.Tk()\n",
     "canvas = tk.Canvas(root, width=1920, height=1080)\n",


### PR DESCRIPTION
Getting the rendered image with
```
ImageGrab.grab().crop((x0, y0, x1, y1)).save(filename)
```
didn't work for me. I'm on Linux using Wayland, not X11, which doesn't have permissions to grab random parts of the screen. 

This switches `dump_gui` to use a combination of [`canvas.postscript`](https://tkinter-docs.readthedocs.io/en/latest/widgets/canvas.html#Canvas.postscript) and `PIL.Image` to get the drawn image into a file.