### PR TITLE
Fix compilation of CPU version

### DIFF
--- a/FastDBC.cpp
+++ b/FastDBC.cpp
@@ -1,5 +1,6 @@
 #include "FastDBC.h"
 #include <algorithm>
+#include <cstring>
 
 template <typename T>
 T max4(T a, T b, T c, T d) {
@@ -12,7 +13,7 @@ T min4(T a, T b, T c, T d) {
 }
 
 void seqDBC(unsigned char* I, const int M, const unsigned char G, float Nr[]) {
-    unsigned char *Imax = new unsigned char[M * M]; 
+    unsigned char *Imax = new unsigned char[M * M];
     unsigned char *Imin = new unsigned char[M * M];
 
     memcpy(Imax, I, sizeof(unsigned char) * M * M);

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,12 @@ help: 			## Show this help
 .PHONY: help build_cpu build_gpu clean
 
 build_cpu:
-	cmake -Gninja -Bbuild_cpu -DCMAKE_BUILD_TYPE=Release -S. -Bbuild_cpu -C CMakeLists.txt
+	cmake -GNinja -Bbuild_cpu -DCMAKE_BUILD_TYPE=Release -C CMakeLists.txt
+	cmake --build build_cpu
 
 build_gpu:
-	cmake -Gninja -Bbuild_gpu -DCMAKE_BUILD_TYPE=Release -S. -Bbuild_gpu -C CMakeLists_GPU.txt
+	cmake -GNinja -Bbuild_gpu -DCMAKE_BUILD_TYPE=Release -C CMakeLists_GPU.txt
+	cmake --build build_gpu
 
 clean:
 	rm -rf build_cpu build_gpu


### PR DESCRIPTION
From the commits, this fixes a few issues:
* `make build_cpu` wasn't working for me: it should have read `-GNinja` (uppercase N)
* `make build_cpu` didn't compile the code as well, just set up cmake.
* `FastDBC.cpp` was missing an include of `cstring` for `memcpy`. This may be a Linux / GCC / version thing, not sure.