### PR TITLE
Enable warnings in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,18 @@
 cmake_minimum_required(VERSION 3.15...3.31)
 project(
-    FractalDimensionComputation_CPU
+    FractalDimensionComputation
     VERSION 1.0
     LANGUAGES CXX)
 
 find_package(OpenCV REQUIRED)
 include_directories(${OpenCV_INCLUDE_DIRS})
 
-add_executable(
-    FractalDimensionComputation_CPU
-    main.cpp bcCPU.cpp FastDBC.cpp)
-target_link_libraries(FractalDimensionComputation_CPU PRIVATE ${OpenCV_LIBS})
+set(EXE_CPU FractalDimensionComputation_CPU)
+add_executable(${EXE_CPU} main.cpp bcCPU.cpp FastDBC.cpp)
+target_link_libraries(${EXE_CPU} PRIVATE ${OpenCV_LIBS})
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    target_compile_options(${EXE_CPU} PRIVATE -Wall -Wextra -Wpedantic)
+elseif (MSVC)
+    target_compile_options(${EXE_CPU} PRIVATE /W4)
+endif()

--- a/FastDBC.cpp
+++ b/FastDBC.cpp
@@ -28,8 +28,8 @@ void seqDBC(unsigned char* I, const int M, const unsigned char G, float Nr[]) {
 
         h = h == 0.0 ? 0.001 : h;
 
-        for (unsigned long i = 0; i < (M - 1); i += s) {
-            for (unsigned long j = 0; j < (M - 1); j += s) {
+        for (int i = 0; i < (M - 1); i += s) {
+            for (int j = 0; j < (M - 1); j += s) {
                 Imax[i * M + j] = max4(Imax[i * M + j], Imax[i * M + j + s / 2], Imax[(i + s / 2) * M + j], Imax[(i + s / 2) * M + j + s / 2]);
                 Imin[i * M + j] = min4(Imin[i * M + j], Imin[i * M + j + s / 2], Imin[(i + s / 2) * M + j], Imin[(i + s / 2) * M + j + s / 2]);
 

--- a/bcCPU.cpp
+++ b/bcCPU.cpp
@@ -21,7 +21,7 @@
 void seqBC2D(unsigned char* M, const int m, float* n) {
 	unsigned int s = 2;
 	unsigned int size = m;
-	unsigned char ni = 0; 
+	unsigned char ni = 0;
 
 	while (size > 2) {
 		int sm = s >> 1; // s/2
@@ -29,10 +29,10 @@ void seqBC2D(unsigned char* M, const int m, float* n) {
 		unsigned long ismm;
 
 		n[ni] = 0;
-		for (unsigned long i = 0; i < (m - 1); i += s) {
+		for (int i = 0; i < (m - 1); i += s) {
 			im = i * m;
 			ismm = (i + sm) * m;
-			for (unsigned long j = 0; j < (m - 1); j += s) {
+			for (int j = 0; j < (m - 1); j += s) {
 				M[im + j] = M[(im)+j] || M[(im)+(j + sm)] || M[ismm + j] || M[ismm + (j + sm)];
 				n[ni] += M[im + j];
 			}

--- a/main.cpp
+++ b/main.cpp
@@ -221,7 +221,7 @@ chrono::duration<double> computeCPUAlgorithm(unsigned char *imageMat, float *box
         seqBC2D(imageMatCopy, matSize, boxArray);
         stop = std::chrono::system_clock::now();
     }
-    
+
     std::chrono::duration<double> timeCPU = stop - start;
 
     return timeCPU;
@@ -247,8 +247,8 @@ void clearResources(unsigned char *imageMat, float *boxArray)
 
 int main(int argc, char *argv[])
 {
-    char *filename = new char[0];
-    char *algorithm = new char[0];
+    char *filename = nullptr;
+    char *algorithm = nullptr;
     int runCount = 10;
     string filePath = "";
 


### PR DESCRIPTION
This adds some warnings by default and fixes all the issues they pointed out:
* some `-Wsign-compare` for comparing unsigned and signed integers.
* some `-Walloc-size` for allocating 0 sized arrays.

Fixes #9.